### PR TITLE
Import ABC from collections.abc instead of collections for Python 3.9 compatibility

### DIFF
--- a/distroinfo/parse.py
+++ b/distroinfo/parse.py
@@ -16,6 +16,11 @@ import collections
 import copy
 import six
 
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
+
 from distroinfo import exception
 
 
@@ -48,7 +53,7 @@ def parse_releases(info):
         releases = info['releases']
     except KeyError:
         raise exception.MissingRequiredSection(section='releases')
-    if not isinstance(releases, collections.Iterable):
+    if not isinstance(releases, Iterable):
         raise exception.InvalidInfoFormat(
             msg="'releases' section must be iterable")
     if isinstance(releases, dict):
@@ -148,7 +153,7 @@ def parse_packages(info, apply_tag=None):
         pkgs = info['packages']
     except KeyError:
         raise exception.MissingRequiredSection(section='packages')
-    if not isinstance(pkgs, collections.Iterable):
+    if not isinstance(pkgs, Iterable):
         raise exception.InvalidInfoFormat(
             msg="'packages' section must be iterable")
     if isinstance(pkgs, dict):

--- a/distroinfo/query.py
+++ b/distroinfo/query.py
@@ -13,10 +13,14 @@
 # under the License.
 
 from __future__ import print_function
-import collections
 from functools import partial
 import re
 import six
+
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 from distroinfo import exception
 
@@ -77,7 +81,7 @@ def _match_pkg(rexen, pkg):
         if isinstance(val, six.string_types):
             if not re.search(rex, val):
                 return False
-        elif isinstance(val, collections.Iterable):
+        elif isinstance(val, Iterable):
             # collection matches if any item of collection matches
             found = False
             for e in val:


### PR DESCRIPTION
Fixes #5 